### PR TITLE
Fix broken link in documentation and make bokeh links dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.2 (2024-06-01)
 
+- Version of installed `bokeh` package is now used to create matching JavaScript links.  
 - Fixed invalid link in Configuration page of documentation.
 
 ## 2.1.1 (2024-06-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.2 (2024-06-01)
+
+- Fixed invalid link in Configuration page of documentation.
+
 ## 2.1.1 (2024-06-01)
 
 - Fixed logging by replacing custom logger creation with standard `getLogger` call. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ separately in `external_links.ini`.
 `config.ini` file controls behaviour of Pyreball as well as how various elements should be displayed in the final HTML.
 The default `config.ini` looks like this:
 
-{{ inline_source("pyreball/cfg/config.ini", "cfg") }}
+{{ inline_source("src/pyreball/cfg/config.ini", "cfg") }}
 
 Detailed description is provided in
 section [config.ini vs. CLI arguments vs. function arguments](#configini-vs-cli-arguments-vs-function-arguments).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,9 @@ added to the HTML `<head>` element.
 Some libraries, e.g. [DataTables](https://datatables.net/), require also [jQuery](https://jquery.com/), which is listed
 separately in `external_links.ini`.
 
+All links in `external_links.ini` are fixed except for Bokeh links.
+Bokeh links contain placeholder `{BOKEH_VERSION}`, which is replaced by the version of installed `bokeh` package during report generation by Pyreball.
+
 ### config.ini File
 
 `config.ini` file controls behaviour of Pyreball as well as how various elements should be displayed in the final HTML.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyreball"
-version = "2.1.1"
+version = "2.1.2"
 description = "Python reporting tool."
 authors = ["Karel Vaculik <vaculik.dev@gmail.com>"]
 license = "Apache-2.0"

--- a/src/pyreball/__main__.py
+++ b/src/pyreball/__main__.py
@@ -226,6 +226,27 @@ def _contains_class(html_text: str, class_name: str) -> bool:
     return re.search(pattern, html_text) is not None
 
 
+def _fill_bokeh_version_in_external_links(external_links: Dict[str, List[str]]) -> None:
+    """Fill-in version of installed bokeh package into external links.
+
+    The links are updated inplace.
+
+    Args:
+        external_links: Dictionary with external links.
+    """
+    if "bokeh" in external_links:
+        try:
+            import bokeh
+
+            bokeh_version = bokeh.__version__
+        except ImportError:
+            bokeh_version = "3.2.2"
+        external_links["bokeh"] = [
+            link.replace("{BOKEH_VERSION}", bokeh_version)
+            for link in external_links["bokeh"]
+        ]
+
+
 def _insert_js_and_css_links(
     html_content: str, external_links: Dict[str, List[str]]
 ) -> str:
@@ -721,6 +742,7 @@ def main() -> None:
         filename=LINKS_INI_FILENAME,
         directory=config_directory,
     )
+    _fill_bokeh_version_in_external_links(external_links=external_links)
 
     parameters = merge_parameter_dictionaries(
         primary_parameters=cli_parameters,

--- a/src/pyreball/cfg/external_links.ini
+++ b/src/pyreball/cfg/external_links.ini
@@ -4,11 +4,11 @@ altair =
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
 bokeh =
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.2.2.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.2.2.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.2.2.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.2.2.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-3.2.2.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-{BOKEH_VERSION}.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-{BOKEH_VERSION}.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-{BOKEH_VERSION}.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-gl-{BOKEH_VERSION}.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-{BOKEH_VERSION}.min.js" crossorigin="anonymous"></script>
 datatables =
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
- Version of installed `bokeh` package is now used to create matching JavaScript links.  
- Fixed invalid link in Configuration page of documentation.